### PR TITLE
Build bcachefs-tools with podman for gokrazy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt install -y zip wget curl golang build-essential \
+    pkg-config libaio-dev libblkid-dev libkeyutils-dev \
+    liblz4-dev libsodium-dev liburcu-dev libzstd-dev \
+    uuid-dev zlib1g-dev valgrind libudev-dev udev git \
+    python3 python3-docutils libclang-dev debhelper dh-python 
+
+# install rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ENV SOURCE_DATE_EPOCH 1600000000
+
+# build bcachefs-tools
+RUN mkdir /src /bins && wget https://github.com/koverstreet/bcachefs-tools/archive/refs/tags/v1.7.0.zip && unzip -d /src /v1.7.0.zip && mv /src/bcachefs-tools-1.7.0/* /src
+RUN cd /src && make -j$(nproc) && cp ./bcachefs /bins/bcachefs && make clean
+
+# freeze bcachefs binary
+RUN go run github.com/gokrazy/freeze/cmd/freeze@latest /bins/bcachefs 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# Using podman build --platform to cross compile. Podman will run non-native
+# platforms via `qemu-user-static` by default.
+
+all: third_party/bcachefs-tools-1.7.0/amd64/bcachefs third_party/bcachefs-tools-1.7.0/arm64/bcachefs third_party/bcachefs-tools-1.7.0/arm/bcachefs 
+.PHONY : all
+
+third_party/bcachefs-tools-1.7.0/amd64/bcachefs: Dockerfile
+	podman build --platform linux/amd64 -t bcachefs-tools-amd64 .
+	podman run --rm -v ./third_party/bcachefs-tools-1.7.0/amd64:/tmp/bins:z bcachefs-tools-amd64 /bin/bash -c "tar --strip-components=1 -C /tmp/bins -xf /tmp/freeze/* "
+
+
+third_party/bcachefs-tools-1.7.0/arm64/bcachefs: Dockerfile
+	podman build --platform linux/arm64 -t bcachefs-tools-arm64 .
+	podman run --rm -v ./third_party/bcachefs-tools-1.7.0/arm64:/tmp/bins:z bcachefs-tools-arm64 /bin/bash -c "tar --strip-components=1 -C /tmp/bins -xf /tmp/freeze/* "
+
+third_party/bcachefs-tools-1.7.0/arm/bcachefs: Dockerfile
+	podman build --platform linux/arm -t bcachefs-tools-arm .
+	podman run --rm -v ./third_party/bcachefs-tools-1.7.0/arm:/tmp/bins:z bcachefs-tools-arm /bin/bash -c "tar --strip-components=1 -C /tmp/bins -xf /tmp/freeze/* "
+
+clean:
+	rm -f third_party/bcachefs-tools-1.7.0/amd64/*
+	rm -f third_party/bcachefs-tools-1.7.0/arm64/*
+	rm -f third_party/bcachefs-tools-1.7.0/arm/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# gokrazy mkfs
+
+This program is intended to be run on gokrazy only, where it will create an ext4
+file system on the perm partition and then reboot your system. If `/perm` is
+already mounted, the program will exit without changing anything.
+
+The gokrazy mkfs program includes a [frozen
+copy](https://github.com/gokrazy/freeze) of the `mke2fs` program from the
+`e2fsprogs` package from Debian.
+
+## Usage
+
+You can either add this program to your gokrazy instance:
+
+```
+gok add github.com/gokrazy/mkfs
+```
+
+…or, if you want to run it only once without otherwise including it in your
+installation, you can use `gok run`:
+
+```
+git clone https://github.com/gokrazy/mkfs
+cd mkfs
+gok -i bakery run
+```
+
+

--- a/README.md
+++ b/README.md
@@ -1,28 +1,34 @@
-# gokrazy mkfs
+# gokrazy mkfs.bcachefs
 
-This program is intended to be run on gokrazy only, where it will create an ext4
-file system on the perm partition and then reboot your system. If `/perm` is
-already mounted, the program will exit without changing anything.
+This program is intended to be run on gokrazy only, where it will create an
+bcachefs file system on the perm partition and then reboot your system. If
+`/perm` is already mounted, the program will exit without changing anything.
 
 The gokrazy mkfs program includes a [frozen
-copy](https://github.com/gokrazy/freeze) of the `mke2fs` program from the
-`e2fsprogs` package from Debian.
+copy](https://github.com/gokrazy/freeze) of
+[`bcachefs-tools`](https://github.com/koverstreet/bcachefs-tools) 
 
 ## Usage
 
 You can either add this program to your gokrazy instance:
 
 ```
-gok add github.com/gokrazy/mkfs
+gok add github.com/gokrazy/mkfs.bcachefs
 ```
 
 …or, if you want to run it only once without otherwise including it in your
 installation, you can use `gok run`:
 
 ```
-git clone https://github.com/gokrazy/mkfs
-cd mkfs
+git clone https://github.com/gokrazy/mkfs.bcachefs
+cd mkfs.bcachefs
 gok -i bakery run
 ```
 
+## Building
+Install `podman` as well as `qemu-user-static-binfmt` or `qemu-user-static`.
+Bcachefs-tools are built via emulation instead of cross compilation currently.
+Then:
+`make
+clean && make all`
 

--- a/embed_linux_amd64.go
+++ b/embed_linux_amd64.go
@@ -1,0 +1,8 @@
+package main
+
+import "embed"
+
+const bcachefsRoot = "third_party/bcachefs-tools-1.7.0/amd64"
+
+//go:embed third_party/bcachefs-tools-1.7.0/amd64/*
+var bcachefsEmbedded embed.FS

--- a/embed_linux_arm.go
+++ b/embed_linux_arm.go
@@ -1,0 +1,8 @@
+package main
+
+import "embed"
+
+const bcachefsRoot = "third_party/bcachefs-tools-1.7.0/amd64"
+
+//go:embed third_party/bcachefs-tools-1.7.0/arm
+var bcachefsEmbedded embed.FS

--- a/embed_linux_arm64.go
+++ b/embed_linux_arm64.go
@@ -1,0 +1,8 @@
+package main
+
+import "embed"
+
+const bcachefsRoot = "third_party/bcachefs-tools-1.7.0/arm64"
+
+//go:embed third_party/bcachefs-tools-1.7.0/arm64/*
+var bcachefsEmbedded embed.FS

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gokrazy/mkfs
+module github.com/gokrazy/mkfs.bcachefs
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/gokrazy/mkfs
+
+go 1.17
+
+require github.com/gokrazy/internal v0.0.0-20210621162516-1b3b5687a06d
+
+require github.com/google/go-cmp v0.5.9 // indirect

--- a/mkfs.go
+++ b/mkfs.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/gokrazy/internal/rootdev"
+)
+
+func makeFilesystemNotWar() error {
+	b, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		parts := strings.Fields(line)
+		if len(parts) < 5 {
+			continue
+		}
+		mountpoint := parts[4]
+		log.Printf("Found mountpoint %q", parts[4])
+		if mountpoint == "/perm" {
+			log.Printf("/perm file system already mounted, nothing to do")
+			return nil
+		}
+	}
+
+	// /perm is not a mounted file system. Try to create a file system.
+	dev := rootdev.Partition(rootdev.Perm)
+	log.Printf("No /perm mountpoint found. Creating file system on %s", dev)
+	tmp, err := os.MkdirTemp("", "gokrazy-mkfs-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	log.Printf("Writing self-contained mke2fs to %s", tmp)
+
+	if err := ioutil.WriteFile(filepath.Join(tmp, "mke2fs"), mke2fs, 0755); err != nil {
+		return err
+	}
+	mkfs := exec.Command(filepath.Join(tmp, "mke2fs"), "-t", "ext4", dev)
+	mkfs.Stdout = os.Stdout
+	mkfs.Stderr = os.Stderr
+	log.Printf("%v", mkfs.Args)
+	if err := mkfs.Run(); err != nil {
+		return fmt.Errorf("%v: %v", mkfs.Args, err)
+	}
+
+	// It is pointless to try and mount the file system here from within this
+	// process, as gokrazy services are run in a separate mount namespace.
+	// Instead, we trigger a reboot so that /perm is mounted early and
+	// the whole system picks it up correctly.
+	httpPassword, err := readConfigFile("gokr-pw.txt")
+	if err != nil {
+		return fmt.Errorf("could read neither /perm/gokr-pw.txt, nor /etc/gokr-pw.txt, nor /gokr-pw.txt: %v", err)
+	}
+
+	port, err := ioutil.ReadFile("/etc/http-port.txt")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", "http://localhost:"+string(port)+"/reboot", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("gokrazy:"+httpPassword)))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		return fmt.Errorf("rebooting device: unexpected HTTP status code: got %d, want %d", got, want)
+	}
+
+	return nil
+}
+
+// readConfigFile reads configuration files from /perm /etc or / and returns
+// trimmed content as string.
+//
+// TODO: de-duplicate this with gokrazy.go into a gokrazy/internal package
+func readConfigFile(fileName string) (string, error) {
+	str, err := ioutil.ReadFile("/perm/" + fileName)
+	if err != nil {
+		str, err = ioutil.ReadFile("/etc/" + fileName)
+	}
+	if err != nil && os.IsNotExist(err) {
+		str, err = ioutil.ReadFile("/" + fileName)
+	}
+
+	return strings.TrimSpace(string(str)), err
+}
+
+func main() {
+	if err := makeFilesystemNotWar(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	}
+	// tell gokrazy to not supervise this service, it’s a one-off:
+	os.Exit(125)
+}


### PR DESCRIPTION
I never figured out how to cross-compile bcachefs-tools directly but I got the bcachefs equivalent to `gokrazy/mkfs` working using `podman build --platform=ARCH` instead. Open for feedback on approach here!

Also, when executing `bcachefs format /dev/...` in mkfs.go it seems `format` is somehow getting passed as the first argument and I don't understand why.  I just call `bcachefs /dev/...` and the `format` subcommand is run on gokrazy.