### PR TITLE
increase default block size to 4096

### DIFF
--- a/mkfs.go
+++ b/mkfs.go
@@ -57,7 +57,7 @@ func makeFilesystemNotWar() error {
 	}
 
 	// exec bcachefs format on rootdev partition
-	mkfs := exec.Command(filepath.Join(tmp, "ld-linux-aarch64.so.1"), filepath.Join(tmp, "bcachefs"), "format", dev)
+	mkfs := exec.Command(filepath.Join(tmp, "ld-linux-aarch64.so.1"), filepath.Join(tmp, "bcachefs"), "format", "--block_size=4096", dev)
 	mkfs.Env = append(os.Environ(), "LD_LIBRARY_PATH="+tmp)
 	mkfs.Stdout = os.Stdout
 	mkfs.Stderr = os.Stderr

--- a/mkfs.go
+++ b/mkfs.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -76,7 +75,7 @@ func makeFilesystemNotWar() error {
 		return fmt.Errorf("could read neither /perm/gokr-pw.txt, nor /etc/gokr-pw.txt, nor /gokr-pw.txt: %v", err)
 	}
 
-	port, err := ioutil.ReadFile("/etc/http-port.txt")
+	port, err := os.ReadFile("/etc/http-port.txt")
 	if err != nil {
 		return err
 	}
@@ -102,12 +101,12 @@ func makeFilesystemNotWar() error {
 //
 // TODO: de-duplicate this with gokrazy.go into a gokrazy/internal package
 func readConfigFile(fileName string) (string, error) {
-	str, err := ioutil.ReadFile("/perm/" + fileName)
+	str, err := os.ReadFile("/perm/" + fileName)
 	if err != nil {
-		str, err = ioutil.ReadFile("/etc/" + fileName)
+		str, err = os.ReadFile("/etc/" + fileName)
 	}
 	if err != nil && os.IsNotExist(err) {
-		str, err = ioutil.ReadFile("/" + fileName)
+		str, err = os.ReadFile("/" + fileName)
 	}
 
 	return strings.TrimSpace(string(str)), err


### PR DESCRIPTION
Bcachefs seems to default to 512 as the block size on devices where other filesystems will choose 4096. I've tried to track down what is going on but I think it makes sense to just explicitly set it for mkfs.bcachefs on gokrazy.  This way its at least more visible if someone thinks it should be another value. 4096 block size seems to get better performance on modern hardware according to phoronix benchmarks.

Also I moved `ioutil.ReadFile()` to `os.ReadFile()` because of the deprecation notices